### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 description = "A Xircuits component library for discord!"
 authors = [{ name = "XpressAI", email = "eduardo@xpress.ai" }]
 license = "Apache-2.0"
-readme = "readme.md"
+readme = "README.md"
 repository = "https://github.com/XpressAI/xai-discord"
 keywords = ["xircuits", "discord", "Bot"]
 
 dependencies = [
-    "discord-py==2.4.0",
+    "discord.py==2.4.0",
     "aiohttp==3.10.10"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord-py==2.4.0
+discord-py==2.4.0
 aiohttp==3.10.10


### PR DESCRIPTION
# Description

This PR fixes metadata issues in the `pyproject.toml` of **xai-discord**:
- Corrected `readme` casing to `README.md`.
- Updated dependencies: replaced `discord-py` with `discord.py`.
- Verified `default_example_path` points to a valid example
